### PR TITLE
Add a framework for including predefined specifications.

### DIFF
--- a/labels/predefined/__init__.py
+++ b/labels/predefined/__init__.py
@@ -1,0 +1,82 @@
+import os
+from inspect import isclass
+from warnings import warn
+
+from labels.specifications import Specification
+from importlib import import_module
+
+LETTER_PORTRAIT_WIDTH = 215.9
+LETTER_PORTRAIT_HEIGHT = 279.4
+LETTER_LANDSCAPE_WIDTH = LETTER_PORTRAIT_HEIGHT
+LETTER_LANDSCAPE_HEIGHT = LETTER_PORTRAIT_WIDTH
+
+
+class _PredefinedSpec(Specification):
+    """ Classes derived from this one can specify dimensions as class variables.  All dimensions should be specified
+     from a "portrait" perspective.  The landscape class method will automatically transpose these dimensions if a
+     landscape orientation is needed. """
+    _CALLED_FROM_CLASSMETHOD = False
+
+    def __init__(self, *args, **kwargs):
+        # Encourage the caller to use a factory method instead of calling __init__ directly.
+        if not self._CALLED_FROM_CLASSMETHOD:
+            warn("This specification should only be created using a class method ('portrait' or 'landscape')")
+
+        super().__init__(*args, **kwargs)
+
+        # Reset our internal call marker.
+        _PredefinedSpec._CALLED_FROM_CLASSMETHOD = False
+
+    @classmethod
+    def portrait(cls):
+        cls._CALLED_FROM_CLASSMETHOD = True
+        return cls(sheet_width=LETTER_PORTRAIT_WIDTH,
+                   sheet_height=LETTER_PORTRAIT_HEIGHT,
+                   columns=getattr(cls, 'COLUMNS', None),
+                   rows=getattr(cls, 'ROWS', None),
+                   label_width=getattr(cls, 'LABEL_WIDTH', None),
+                   label_height=getattr(cls, 'LABEL_HEIGHT', None),
+                   corner_radius=getattr(cls, 'CORNER_RADIUS', None),
+                   top_margin=getattr(cls, 'TOP_MARGIN', None),
+                   bottom_margin=getattr(cls, 'BOTTOM_MARGIN', None),
+                   left_margin=getattr(cls, 'LEFT_MARGIN', None),
+                   right_margin=getattr(cls, 'RIGHT_MARGIN', None),
+                   row_gap=getattr(cls, 'ROW_GAP', None),
+                   column_gap=getattr(cls, 'COLUMN_GAP', None))
+
+    @classmethod
+    def landscape(cls):
+        cls._CALLED_FROM_CLASSMETHOD = True
+        return cls(sheet_width=LETTER_LANDSCAPE_WIDTH,
+                   sheet_height=LETTER_LANDSCAPE_HEIGHT,
+                   columns=getattr(cls, 'ROWS', None),
+                   rows=getattr(cls, 'COLUMNS', None),
+                   label_width=getattr(cls, 'LABEL_HEIGHT', None),
+                   label_height=getattr(cls, 'LABEL_WIDTH', None),
+                   corner_radius=getattr(cls, 'CORNER_RADIUS', None),
+                   top_margin=getattr(cls, 'LEFT_MARGIN', None),
+                   bottom_margin=getattr(cls, 'RIGHT_MARGIN', None),
+                   left_margin=getattr(cls, 'TOP_MARGIN', None),
+                   right_margin=getattr(cls, 'BOTTOM_MARGIN', None),
+                   row_gap=getattr(cls, 'COLUMN_GAP', None),
+                   column_gap=getattr(cls, 'ROW_GAP', None))
+
+
+def all_predefined_specs():
+    """ Return an iterator for all predefined specs. The objects returned by the iterator are tuples containing the
+    spec name as a string and the spec class as an object. """
+
+    # Inspect all files in this file's directory
+    for py_file in sorted(os.listdir(os.path.dirname(__file__))):
+
+        # If it's a py file and not a under/dunder file, it may contain specifications
+        if py_file.endswith('.py') and not py_file.startswith('_'):
+
+            # Import the file so we can inspect it.
+            py_module, _ = os.path.splitext(py_file)
+            imported = import_module('labels.predefined.' + py_module)
+
+            for member_name, member_value in sorted(vars(imported).items()):
+                # If we find a public class derived from _PredefinedSpec, yield.
+                if not member_name.startswith('_') and isclass(member_value) and issubclass(member_value, _PredefinedSpec):
+                    yield '.'.join([py_module, member_name]), member_value

--- a/labels/predefined/__main__.py
+++ b/labels/predefined/__main__.py
@@ -1,0 +1,8 @@
+""" A convenient way to print a list of all known predefined specs. """
+from __future__ import print_function
+from labels.predefined import all_predefined_specs
+
+print("Predefined Specifications:")
+
+for spec_name, _ in all_predefined_specs():
+    print(spec_name)

--- a/labels/predefined/avery.py
+++ b/labels/predefined/avery.py
@@ -1,0 +1,13 @@
+from labels.predefined import _PredefinedSpec
+
+
+class A22822(_PredefinedSpec):
+    """ Specification for Avery 22822, 2" x 3" labels, 10 per sheet, 8.5"x11" paper size. """
+    COLUMNS = 2
+    ROWS = 4
+    LABEL_WIDTH = 78
+    LABEL_HEIGHT = 50.8
+    CORNER_RADIUS = 4
+    ROW_GAP = 3
+    LEFT_MARGIN = 21.5
+    COLUMN_GAP = 20.25

--- a/labels/tests/test_predefined_specs.py
+++ b/labels/tests/test_predefined_specs.py
@@ -1,0 +1,25 @@
+import warnings
+from unittest import TestCase
+
+from labels import predefined
+from labels.specifications import Specification
+
+
+class TestPredefinedSpecs(TestCase):
+    def test_get_all_predefined(self):
+        for spec_name, spec_class in predefined.all_predefined_specs():
+            # Ensure that each returned spec is a tuple containing class name and class object
+            self.assertIsInstance(spec_name, str)
+            self.assertTrue(issubclass(spec_class, Specification))
+
+    def test_warning_for_direct_construction(self):
+        # Get an arbitrary spec class
+        spec_class = next(predefined.all_predefined_specs())[1]
+
+        # Verify we get a warning when constructing it directly
+        with warnings.catch_warnings(record=True) as warning_list:
+            # Pass 6 positional arguments as required by Specification
+            spec_class(1, 1, 1, 1, 1, 1)
+
+            # That should generate a warning since we shouldn't use the constructor directly.
+            self.assertEqual(len(warning_list), 1)


### PR DESCRIPTION
I'm not sure if something like this is desired in pylabels, but since I needed to build a library of predefined specifications for my own use, I thought I would see if you'd like to include it directly.

The idea is to house a number of predefined specifications for known label types.  In this PR, I've included a specification for Avery 22822.  I focused on making the definition super simple, with a built-in conversion for portrait vs landscape orientation.

I included some unit tests for this new approach as well as a convenience method for listing known specifications (run `python -m labels.predefined`)

Let me know what you think.  I'm happy to make additional changes, but thought this would be a good spot to start the conversation.