### PR TITLE
set PDF preference to print without scaling

### DIFF
--- a/labels/sheet.py
+++ b/labels/sheet.py
@@ -482,6 +482,7 @@ class Sheet(object):
 
         # Create a canvas.
         canvas = Canvas(filelike, pagesize=self._pagesize)
+        canvas.setViewerPreference("PrintScaling", "None")
 
         # Render each created page onto the canvas.
         for page in self._pages:


### PR DESCRIPTION
When printing labels, it's important to not scale the page, but many PDF viewers default to doing so anyway. This would have ReportLab set the Viewer Preference for no print scaling.